### PR TITLE
Markdown Parser Updates

### DIFF
--- a/app/parsers/markdown-parser.inc.php
+++ b/app/parsers/markdown-parser.inc.php
@@ -1767,20 +1767,20 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 	### HTML Block Parser ###
 
 	# Tags that are always treated as block tags:
-	var $block_tags_re = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|form|fieldset|iframe|hr|legend|article|aside|audio|figure|footer|header|hgroup|nav|section|video';
+	var $block_tags_re = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|form|fieldset|output|iframe|hr|legend|article|section|nav|aside|header|hgroup|footer|figcaption|figure';
 
 	# Tags treated as block tags only if the opening tag is alone on it's line:
-	var $context_block_tags_re = 'script|noscript|math|ins|del';
+	var $context_block_tags_re = 'script|noscript|style|ins|del|iframe|object|source|track|param|math|svg|canvas|audio|video';
 
 	# Tags where markdown="1" default to span mode:
 	var $contain_span_tags_re = 'p|h[1-6]|li|dd|dt|td|th|legend|address';
 
 	# Tags which must not have their contents modified, no matter where
 	# they appear:
-	var $clean_tags_re = 'script|math';
+	var $clean_tags_re = 'script|style|math|svg';
 
 	# Tags that do not need to be closed.
-	var $auto_close_tags_re = 'hr|img';
+	var $auto_close_tags_re = 'hr|img|param|source|track|br';
 
 
 	function hashHTMLBlocks($text) {


### PR DESCRIPTION
The PHP Markdown Block Parser is out of date, as it is missing a few HTML5 tags. This causes certain block-level elements to ruin the valid HTML output. These include the `<output>`, `<figcaption>`, `<object>`, `<source>`, `<track>`, `<param>`, `<math>`, `<svg>`, `<canvas>` tags (and probably a few others that I forgot to mention).

Granted, these tags are not commonly used unless building a website that uses HTML5 technologies &mdash; still, eventually _someone's_ going to notice, right?

I've only made modifications to the relevant portions of the Markdown_Parser class, as things like the Wordpress plugin are not used in Cindy. Perhaps in the future, unused code can be removed from the `markdown-parser.inc.php`, as that will cut down on the overall size of Cindy.
