### PR TITLE
Deprecated php features

### DIFF
--- a/app/page-data.inc.php
+++ b/app/page-data.inc.php
@@ -110,13 +110,15 @@ class PageData {
 		$split_url = explode("/", $page->url_path);
 		$page->slug = $split_url[count($split_url) - 1];
 		# @page_name
-		$page->page_name = ucfirst(preg_replace('/[-_](.)/e', "' '.strtoupper('\\1')", $page->data['@slug']));
+		$page->page_name = ucfirst(preg_replace_callback('/[-_](.)/', function ($matches) {
+      return ' '.strtoupper($matches[1]);
+    }, $page->data['@slug']));
 		# @root_path
 		$page->root_path = Helpers::relative_root_path();
-		
+
 		# @docs
 		$page->docs = Config::$docs_folder;
-		
+
 		# @thumb
 		$page->thumb = self::get_thumbnail($page->file_path);
 		# @current_year


### PR DESCRIPTION
According to the [PHP manual](http://php.net/manual/en/function.preg-replace.php), the /e modifier for preg_replace() is deprecated as of PHP 5.5.0. They recommend the use of preg_replace_callback() instead, as using the /e modifier may open up security vulnerabilities. The `PREG_REPLACE_EVAL` modifier gives attackers the ability to execute arbitrary PHP code and practically complete access to the server.

While the only person who theoretically is able to edit text files is the maintainer, its a better idea to protect against it instead of waiting for a disaster to strike. I've made the necessary changes to `page-data.inc.php` to fix this issue.
