### PR TITLE
Plugins 404 path fix

### DIFF
--- a/app/plugin/plugin.inc.php
+++ b/app/plugin/plugin.inc.php
@@ -27,7 +27,7 @@ abstract class Plugin {
 				$this->assets .= 'inject "@root_path/plugins/'.$config["folder_name"].'/'.$asset."\"\n";
 			}
 		}
-		$this->template_file = "/plugins/".$config["folder_name"]."/".$config["template_file"];
+		$this->template_file = "@root_path/plugins/".$config["folder_name"]."/".$config["template_file"];
 		$this->type = $config["type"];
 		$this->width = $config["width"];
 		$this->height = $config["height"];


### PR DESCRIPTION
When running Cindy from a folder other than the site root, the contact-form plugin import gives a 404 error. This is because it searches in the rootpath for the non-existent plugins folder. I've changed the `app/plugin/plugin.inc.php` file to search relative to the site root, so that the contact-form plugin should work now.
