### PR TITLE
Chrome css image holder maxwidth

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -67,7 +67,7 @@ div#project-navigation { margin: 0px 0px 0px 20px; }
 div#project-navigation p, div#gallery-navigation p { margin: 0px 0px 1px; }
 
 div#image-wrapper { overflow: hidden; width: 560px; }
-div#image-wrapper div#image-holder { width: 100000000px; }
+div#image-wrapper div#image-holder { width: 35791394px; }
 div#image-wrapper div#image-holder div.image { float: left; width: 560px; }
 
 img.project-thumb { padding: 0px 10px 5px 0px; float: left; display: none; }


### PR DESCRIPTION
The max width of IMG tags in Chrome 22 breaks at widths greater than 35791394px. This affects other (older) Webkit browsers (late 2012), but was fixed in [December 2012](https://bugs.webkit.org/show_bug.cgi?id=102735). In certain environments (say, in an office or school), the browser might not always be up to date, and so this fix addresses these older browsers. Specifically, this affects the `width`, `height`, `left` and `top` properties.

I've modified `screen.css` as a workaround for older Webkit-based browsers that have this issue.
