### PR TITLE
Better timezone setting function

### DIFF
--- a/app/stacey.inc.php
+++ b/app/stacey.inc.php
@@ -24,7 +24,12 @@ class Stacey {
 
 	function php_fixes() {
 		# in PHP/5.3.0 they added a requisite for setting a default timezone, this should be handled via the php.ini, but as we cannot rely on this, we have to set a default timezone ourselves
-		if(function_exists('date_default_timezone_set')) date_default_timezone_set('Australia/Melbourne');
+		if(function_exists('date_default_timezone_set')) {
+			if(function_exists('date_default_timezone_get') && date_default_timezone_get() != 'UTC')
+				date_default_timezone_set(date_default_timezone_get());
+			else
+				date_default_timezone_set('Australia/Melbourne');
+		}
 	}
 
 	function set_content_type($template_file) {


### PR DESCRIPTION
This new function will check whether the specified functions exist (`date_default_timezone_get()` and `date_default_timezone_set()`), and will use the timezone value, if specified, in the php.ini. If not, it will default to the Australia/Melbourne timezone that it has always used. Some server configurations will cause the `date_default_timezone_get()` function to return 'UTC', instead of the proper timezone, so the check aims to fix that by setting the Australia/Melbourne timezone instead.

It is necessary for a timezone to be set, because in PHP 5.3+, there's a requisite for a default timezone.

I've modified the `php_fixes()` function in `app/stacey.inc.php`.
