### PR TITLE
Use the static variables set in config.php instead

### DIFF
--- a/app/asset-types/page.inc.php
+++ b/app/asset-types/page.inc.php
@@ -65,7 +65,7 @@ class Page {
 	}
 
 	static function template_file($template_name) {
-		$template_file = glob('./templates/'.$template_name.'.*');
+		$template_file = glob(Config::$templates_folder.'/'.$template_name.'.*');
 		# return template if one exists
 		return isset($template_file[0]) ? $template_file[0] : false;
 	}

--- a/app/cache.inc.php
+++ b/app/cache.inc.php
@@ -17,7 +17,7 @@ class Cache {
 
 	function __construct($file_path, $template_file) {
 		# turn a base64 of the current route into the name of the cache file
-		$this->cachefile = './app/_cache/'.$this->base64_url($file_path);
+		$this->cachefile = Config::$cache_folder.'/'.$this->base64_url($file_path);
 		# collect an md5 of all files
 		$this->hash = $this->create_hash();
 		# determine our file type so we know how (and if) to comment
@@ -35,7 +35,7 @@ class Cache {
 
 	function create($route) {
 		$page = new Page($route);
-		
+
 		# start output buffer
 		ob_start();
 		echo $page->parse_template();

--- a/app/helpers.inc.php
+++ b/app/helpers.inc.php
@@ -31,7 +31,7 @@ class Helpers {
 		# if the url is empty, we're looking for the index page
 		$url = empty($url) ? 'index': $url;
 
-		$file_path = './content';
+		$file_path = Config::$content_folder;
 		# Split the url and recursively unclean the parts into folder names
 		$url_parts = explode('/', $url);
 		foreach($url_parts as $u) {
@@ -53,10 +53,10 @@ class Helpers {
 	static function file_cache($dir = false) {
 		if(!self::$file_cache) {
 			# build file cache
-			self::build_file_cache('./content');
-			self::build_file_cache('./plugins');
-			self::build_file_cache('./app');
-			self::build_file_cache('./templates');
+			self::build_file_cache(Config::$content_folder);
+			self::build_file_cache(Config::$plugins_folder);
+			self::build_file_cache(Config::$app_folder);
+			self::build_file_cache(Config::$templates_folder);
 		}
 		if($dir && !self::$file_cache[$dir]) return array();
 		return $dir ? self::$file_cache[$dir] : self::$file_cache;
@@ -135,7 +135,8 @@ class Helpers {
 		return $last_modified;
 	}
 
-	static function site_last_modified($dir = './content') {
+	static function site_last_modified($dir = false) {
+		if (!$dir) $dir = Config::$content_folder;
 		$last_updated = 0;
 		foreach(Helpers::list_files($dir, '/.*/', false) as $file) {
 			if(filemtime($file) > $last_updated) $last_updated = filemtime($file);
@@ -159,7 +160,7 @@ class Helpers {
 	static function human_filesize($size, $max = null, $decimal_sep = ".") {
 		$decimal_sep = Config::$decimal_seperator;
 		$decimal_places = Config::$file_size_decimal_places;
-		
+
 		$retstring = '%01.'.$decimal_places.'f %s';
 		$sys['prefix'] = array('B', 'kB', 'MB', 'GB', 'TB', 'PB');
 		$sys['size']   = 1024;
@@ -181,7 +182,7 @@ class Helpers {
 		if ($decimal_sep != ".") { $ret = str_replace(".", $decimal_sep, $ret); }
 		return $ret;
 	}
-	
+
 	static function serialize_get_string($data) {
 		$get = "?";
 		foreach($data as $k=>$v) {

--- a/app/page-data.inc.php
+++ b/app/page-data.inc.php
@@ -28,7 +28,7 @@ class PageData {
 		array_pop($split_path);
 		$parent_path = array(implode('/', $split_path));
 
-		return $parent_path[0] == './content' ? array() : $parent_path;
+		return $parent_path[0] == Config::$content_folder ? array() : $parent_path;
 	}
 
 	static function get_parents($file_path, $url) {
@@ -156,14 +156,14 @@ class PageData {
 
 	static function create_collections($page) {
 		# $root
-		$page->root = Helpers::list_files('./content', '/^\d+?\./', true);
+		$page->root = Helpers::list_files(Config::$content_folder, '/^\d+?\./', true);
 		# $parent
 		$parent_path = self::get_parent($page->file_path, $page->url_path);
 		$page->parent = $parent_path;
 		# $parents
 		$page->parents = self::get_parents($page->file_path, $page->url_path);
 		# $siblings
-		$parent_path = !empty($parent_path[0]) ? $parent_path[0] : './content';
+		$parent_path = !empty($parent_path[0]) ? $parent_path[0] : Config::$content_folder;
 		$split_url = explode("/", $page->url_path);
 		$page->siblings = Helpers::list_files($parent_path, '/^\d+?\.(?!'.$split_url[(count($split_url) - 1)].')/', true);
 		# $siblings_and_self
@@ -199,7 +199,7 @@ class PageData {
 		$text = (file_exists($content_file_path)) ? file_get_contents($content_file_path) : '';
 
 		# include shared variables for each page
-		$shared = (file_exists('./content/_shared.txt')) ? file_get_contents('./content/_shared.txt') : '';
+		$shared = (file_exists(Config::$content_folder.'/_shared.txt')) ? file_get_contents(Config::$content_folder.'/_shared.txt') : '';
 		# strip any $n matches from the text, as this will mess with any preg_replaces
 		# they get put back in after the template has finished being parsed
 		$text = preg_replace('/\$(\d+)/', "\x02$1", $text);

--- a/app/parsers/template-parser.inc.php
+++ b/app/parsers/template-parser.inc.php
@@ -4,7 +4,8 @@ class TemplateParser {
 
 	static $partials;
 
-	static function collate_partials($dir = './templates/partials') {
+	static function collate_partials($dir = false) {
+		if (!$dir) $dir = Config::$templates_folder.'/partials';
 		foreach(Helpers::file_cache($dir) as $file) {
 			if($file['is_folder']) {
 				self::collate_partials($file['path']);

--- a/app/stacey.inc.php
+++ b/app/stacey.inc.php
@@ -139,12 +139,12 @@ class Stacey {
 			if($e->getMessage() == "404") {
 				# return 404 headers
 				header('HTTP/1.0 404 Not Found');
-				if(file_exists($content_folder.'/404')) {
+				if(file_exists(Config::$content_folder.'/404')) {
 					$this->route = '404';
 					$this->create_page(Config::$content_folder);
 				}
-				else if(file_exists('./public/404.html')) {
-						echo file_get_contents('./public/404.html');
+				else if(file_exists(Config::$root_folder.'public/404.html')) {
+						echo file_get_contents(Config::$root_folder.'public/404.html');
 					}
 				else {
 					echo '<h1>404</h1><h2>Page could not be found.</h2><p>Unfortunately, the page you were looking for does not exist here.</p>';

--- a/config.php
+++ b/config.php
@@ -4,8 +4,8 @@ class Config {
 
 	// Seperator for decimal places, mostly '.', e.g 1.21 Gigawatts
 	public static $decimal_seperator = '.';
-	
-	// Number of decimal places of @file_size 
+
+	// Number of decimal places of @file_size
 	public static $file_size_decimal_places = 1;
 
 	public static $root_folder = './';
@@ -15,7 +15,8 @@ class Config {
 	public static $templates_folder = './templates';
 	public static $cache_folder = './app/_cache';
 	public static $extensions_folder = './extensions';
-
+	public static $plugins_folder = './plugins';
+	
 }
 
 ?>


### PR DESCRIPTION
All paths specified now are using the static variables set in `config.php` for ease of future maintenance, and site configuration (if someone chooses to run Cindy from a non-standard directory). In addition, added a variable for the plugins folder.

Modifications have been made to these functions, among other minor changes:
- the `template_file()` function in `app/asset-types/page.inc.php`
- the constructor in `app/cache.inc.php`
- the `file_cache()` and `site_last_modified()` functions in `app/helpers.inc.php`
- the `create_collections()` and `create_textfile_vars()` functions in `app/page-data.inc.php`
- the `collate_partials()` function in `app/parsers/template-parser.inc.php`
- `app/stacey.inc.php`
- `config.php`
