### PR TITLE
htaccess enhancements

### DIFF
--- a/htaccess
+++ b/htaccess
@@ -7,11 +7,11 @@
 
   ErrorDocument 404 /404.html
 
-  # Rewrite any calls to *.html, *.json, *.xml, *.atom, *.rss, *.rdf or *.txt if a folder matching * exists
+  # Rewrite any calls to *.htm, *.html, *.json, *.xml, *.atom, *.rss, *.rdf or *.txt if a folder matching * exists
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_URI} !public/
   RewriteCond %{DOCUMENT_ROOT}/public/$1.$2 !-f
-  RewriteRule (.+)\.(html|json|xml|atom|rss|rdf|txt)$ $1/ [L]
+  RewriteRule (.+)\.(htm|html|json|xml|atom|rss|rdf|txt)$ $1/ [L]
 
   # Add a trailing slash to directories
   RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
I've added the `.html` file extension to the rewrite rules. It’s somewhat silly that `.htm` is rewritten, but not `.html`. Now, we also rewrite .html files if a matching folder exists, like we do with all the other extensions (`.htm`, `.json`, `.xml`, `.atom`, `.rss`, `.rdf`, `.txt`)
