### PR TITLE
Protect against an empty colon_split variable

### DIFF
--- a/app/page-data.inc.php
+++ b/app/page-data.inc.php
@@ -222,6 +222,7 @@ class PageData {
 			# split the string by the first colon
 			$colon_split = explode(':', $match, 2);
 
+			if (!isset($colon_split[1])) $colon_split[1] = '';
 			# replace the only var in your content - @path for your inline html with images and stuff
 			$relative_path = preg_replace('/^\.\//', Helpers::relative_root_path(), $page->file_path);
 			$colon_split[1] = preg_replace('/\@path/', $relative_path.'/', $colon_split[1]);


### PR DESCRIPTION
In case the explode function does not return an array, because there are no colons, we’ve included a safe-guard to protect against unforseen errors. The `explode()` function returns an empty array, should the colon not exist.
