### PR TITLE
CSS fix for 404 pages

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -4,13 +4,13 @@
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8">
     <title>@title, @name's Portfolio </title>
-    <link rel="alternate" type="application/atom+xml" href="@root_path/?/feed/">
-    <link rel="stylesheet" href="@root_path/css/screen.css" type="text/css" media="screen">
+    <link rel="alternate" type="application/atom+xml" href="http://@base_url/?/feed/">
+    <link rel="stylesheet" href="http://@base_url/css/screen.css" type="text/css" media="screen">
   </head>
   <body>
     <div id="container">
       <h1 class="col three">
-        <a href="@root_path">@name</a>
+        <a href="http://@base_url">@name</a>
         <strong>@profession</strong>
       </h1>
       <em class="col three">@email</em>
@@ -19,7 +19,7 @@
       <div id="content" class="col eight">
         <p class="date col one">&para;</p>
         <div class="description col six">
-          <h2 class="col six"><a href="@root_path">@title</a></h2>
+          <h2 class="col six"><a href="http://@base_url">@title</a></h2>
           :images
           @content
           :pdfs

--- a/templates/partials/navigation/children.html
+++ b/templates/partials/navigation/children.html
@@ -2,7 +2,7 @@ if $children do
   <ol class="children">
   foreach $children do
     <li>
-      <a href="@url">@page_name</a>
+      <a href="http://@base_url/@permalink">@page_name</a>
       :children
     </li>
   endforeach

--- a/templates/partials/navigation/navigation.html
+++ b/templates/partials/navigation/navigation.html
@@ -1,7 +1,7 @@
 <ul id="navigation" class="col two">
   foreach $root do
     <li>
-      <a href="@url">@title</a>
+      <a href="http://@base_url/@permalink">@title</a>
       :children
     </li>
   endforeach


### PR DESCRIPTION
Before, CSS would not display correctly on 404 pages, since it used a relative `@root_path` `@variable`, which would give the relative url from a non-existent directory (which sometimes would lead to missing css). I've worked around this in the templates, so that CSS displays properly when you 404 on a directory that is not exactly level above your home directory (ie. yourwebsite.com/some/non/existent/directory/), which uses `@base_url` and `@permalink` instead.

Perhaps a cleaner solution can be created by modifying the behavior of `@variables` when encountering a 404 error instead.
