### PR TITLE
Fix Cindy for PHP 7 compatibility

### DIFF
--- a/app/page-data.inc.php
+++ b/app/page-data.inc.php
@@ -235,9 +235,9 @@ class PageData {
 			# set a variable with a name of 'key' on the page with a value of 'value'
 			# if the template type is xml or html & the 'value' contains a newline character, parse it as markdown
 			if(strpos($colon_split[1], "\n") !== false && preg_match('/xml|htm|html|rss|rdf|atom/', $split_path[1])) {
-				$page->$colon_split[0] = Markdown(trim($colon_split[1]));
+				$page->{$colon_split[0]} = Markdown(trim($colon_split[1]));
 			} else {
-				$page->$colon_split[0] = trim($colon_split[1]);
+				$page->{$colon_split[0]} = trim($colon_split[1]);
 			}
 		}
 	}


### PR DESCRIPTION
PHP 7 made some changes for uniform variable syntax, which is highlighted in detail in this [RFC](https://wiki.php.net/rfc/uniform_variable_syntax). This breaks compatibility with the content parser.

Basically, this means that PHP 7 interprets `$page->$colon_split[0]` as `($page->$colon_split)[0]`, and not `$page->{$colon_split[0]}`, which the code is working under the assumption of.

The change is backwards compatible, but just makes the intentions explicit to the parser (and provides PHP 7 compatibility).
